### PR TITLE
use preact-marquee as class name prefix instead of jsx-marquee

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npm install preact-marquee --save
 
 ```jsx
 import { Component, h } from 'preact';
-import { Marquee } from './Marquee';
+import { Marquee } from 'preact-marquee';
 import './App.css';
 
 class App extends Component {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preact-marquee",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "description": "A <marquee> component for Preact.",
   "author": "Adrian Ramin <adrian.ramin@gmail.com>",
   "main": "dist/Marquee.js",

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
             font-family: 'FontAwesome', sans-serif;
         }
 
-        .jsx-marquee {
+        .preact-marquee {
             padding: 15px;
         }
 

--- a/src/Marquee.spec.tsx
+++ b/src/Marquee.spec.tsx
@@ -16,13 +16,13 @@ beforeEach(() => {
 it('should render twice the item count as default because of looping content', () => {
     const expectedBreakingNewsItems: number = 2;
 
-    expect(app.find('.jsx-marquee__content-item').length).toBe(expectedBreakingNewsItems);
+    expect(app.find('.preact-marquee__content-item').length).toBe(expectedBreakingNewsItems);
 });
 
 it('should animate the marquee content', () => {
-    expect(app.find('.jsx-marquee__content--is-animated').length).toBe(1);
+    expect(app.find('.preact-marquee__content--is-animated').length).toBe(1);
 });
 
 it('should pause the animation when cursor is hovered over', () => {
-    expect(app.find('.jsx-marquee__content--pause-when-hovered').length).toBe(1);
+    expect(app.find('.preact-marquee__content--pause-when-hovered').length).toBe(1);
 });

--- a/src/Marquee.tsx
+++ b/src/Marquee.tsx
@@ -95,16 +95,16 @@ export class Marquee extends Component<Props, State> {
 
     public render(): JSX.Element {
         const cssVariables: string = [
-            `--jsx-marquee--animation-function: ${this.props.animationFunction}`,
-            `--jsx-marquee--animation-delay: ${this.props.startAnimationAfterInSeconds}s`,
-            `--jsx-marquee--content-width: -${this.state.contentWidth}px`,
-            `--jsx-marquee--animation-time: ${this.state.animationTimeInSeconds}s`
+            `--preact-marquee--animation-function: ${this.props.animationFunction}`,
+            `--preact-marquee--animation-delay: ${this.props.startAnimationAfterInSeconds}s`,
+            `--preact-marquee--content-width: -${this.state.contentWidth}px`,
+            `--preact-marquee--animation-time: ${this.state.animationTimeInSeconds}s`
         ].join(';');
 
         return (
-            <div className={'jsx-marquee'} style={cssVariables} ref={this.saveMarqueeReference}>
+            <div className={'preact-marquee'} style={cssVariables} ref={this.saveMarqueeReference}>
                 <div
-                    className={`jsx-marquee__content ${this.state.animationClassName} ${
+                    className={`preact-marquee__content ${this.state.animationClassName} ${
                         this.state.pauseWhenHoveredClassName
                     }`}
                     ref={this.saveContentReference}
@@ -156,14 +156,14 @@ export class Marquee extends Component<Props, State> {
 
     private startAnimation(): void {
         this.setState({
-            animationClassName: 'jsx-marquee__content--is-animated'
+            animationClassName: 'preact-marquee__content--is-animated'
         });
     }
 
     private pauseWhenHovered(): void {
         if (this.props.pauseWhenHovered) {
             this.setState({
-                pauseWhenHoveredClassName: 'jsx-marquee__content--pause-when-hovered'
+                pauseWhenHoveredClassName: 'preact-marquee__content--pause-when-hovered'
             });
         }
     }
@@ -209,7 +209,7 @@ export class Marquee extends Component<Props, State> {
 
         for (let i: number = 0; i < copyCount; ++i) {
             content.push(
-                <div className={`jsx-marquee__content-item`} key={`content-row-${i}`}>
+                <div className={`preact-marquee__content-item`} key={`content-row-${i}`}>
                     {this.props.children}
                 </div>
             );

--- a/src/marquee.scss
+++ b/src/marquee.scss
@@ -1,21 +1,14 @@
 // # Marquee
 
-@mixin jsx-marquee--when-hovered() {
-    .jsx-marquee:hover & {
+@mixin preact-marquee--when-hovered() {
+    .preact-marquee:hover & {
         @content;
     }
 }
 
-@mixin jsx-marquee--center() {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-}
-
 // [1] HACK for Safari (iOS >= 10.3): Safari renders only the first item. This hack forces
 //     the browser to create a new layer which solves our problem with hidden items.
-.jsx-marquee {
+.preact-marquee {
     width: 100%;
     max-width: 100%;
     overflow-x: hidden;
@@ -24,25 +17,25 @@
 }
 
 // ## Content
-.jsx-marquee__content {
+.preact-marquee__content {
     display: inline-block;
 }
 
 // ## Content
 // ### State: is animated
 // Variables are set on runtime in Marquee.tsx.
-.jsx-marquee__content--is-animated {
-    animation-name: jsx-marquee--animation;
-    animation-timing-function: var(--jsx-marquee--animation-function);
-    animation-duration: var(--jsx-marquee--animation-time);
-    animation-delay: var(--jsx-marquee--animation-delay);
+.preact-marquee__content--is-animated {
+    animation-name: preact-marquee--animation;
+    animation-timing-function: var(--preact-marquee--animation-function);
+    animation-duration: var(--preact-marquee--animation-time);
+    animation-delay: var(--preact-marquee--animation-delay);
     animation-iteration-count: infinite;
 }
 
 // ## Content
 // ### State: pause when hovered
-.jsx-marquee__content--pause-when-hovered {
-    @include jsx-marquee--when-hovered() {
+.preact-marquee__content--pause-when-hovered {
+    @include preact-marquee--when-hovered() {
         animation-play-state: paused;
     }
 }
@@ -51,18 +44,18 @@
 // @tag <div/>
 // [1] Give the browser a hint that we will change the transform value,
 //     so the browser can setup appropriate optimizations ahead of time before the element is actually changed.
-.jsx-marquee__content-item {
+.preact-marquee__content-item {
     display: inline-block;
     will-change: transform; // [1]
 }
 
 // [1] Variable is set on runtime in Marquee.tsx.
-@keyframes jsx-marquee--animation {
+@keyframes preact-marquee--animation {
     0% {
         transform: translateX(0);
     }
 
     100% {
-        transform: translateX(var(--jsx-marquee--content-width)); // [1]
+        transform: translateX(var(--preact-marquee--content-width)); // [1]
     }
 }


### PR DESCRIPTION
## What
- use preact-marquee as class name prefix instead of jsx-marquee
